### PR TITLE
Fix Portfolio Projects carousel spacing CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,14 +313,15 @@ case-study
     #projects-track {
           padding-left: 1rem;
           padding-right: 1rem;
+      }
+
 
       #projects-track .carousel-card {
-    margin-right: 1rem;
-    margin-left: 0;
-    padding-bottom: 0.75rem;
+  margin-right: 1rem;
+  margin-left: 0;
+  padding-bottom: 0.75rem;
 }
 
-    }
 .carousel-card {
   flex: 0 0 280px;
   margin-right: 1rem;


### PR DESCRIPTION
This PR fixes the CSS for the Portfolio Projects carousel spacing. It closes the #projects-track rule properly and moves the nested .carousel-card spacing rule outside the block, ensuring the first card is fully visible and spacing is consistent across cards.

Without this fix, the CSS was invalid and prevented the spacing adjustments from applying.