### PR TITLE
fix(chat): update fetch endpoint to vercel proxy and remove stray hyphen

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,7 +890,7 @@ let messages = [ { role: 'system', content: PERSONA } ];
     input.value = '';
     messages.push({ role: 'user', content: msg });
     try {
-      const response = await fetch('/api/chat-proxy',{-
+const response = await fetch('https://tonyabdelmalak-github-io.vercel.app/api/chat-proxy', {   
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
Replace relative /api/chat-proxy path with full Vercel domain (https://tonyabdelmalak-github-io.vercel.app/api/chat-proxy) so the chat widget works on GitHub Pages. Also remove stray hyphen that broke JavaScript syntax.