### PR TITLE
fix(chat): add CORS to proxy and update widget to dedupe and proxy

### DIFF
--- a/api/chat-proxy.js
+++ b/api/chat-proxy.js
@@ -1,4 +1,15 @@
-export default async function handler(req, res) {
+
+ }
+eport default async function handler(req, res) {
+    // Set CORS headers
+  r  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  // Handle preflight requests
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
   // Only allow POST requests
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });


### PR DESCRIPTION
Root cause:
- The chat widget used a Vercel proxy but CORS headers were missing, causing the browser to block cross-origin POST requests and return failed fetch/404 errors.
- Duplicate chat widget markup and event handlers still existed, leading to conflicts.
- The proxy URL string literal was being split across lines during bundling, producing a malformed URL.

Fix:
- In `api/chat-proxy.js`, added CORS headers (`Access-Control-Allow-Origin` and `Access-Control-Allow-Headers`) and preflight handling for `OPTIONS` requests.
- In `assets/js/chat-widget.js`, removed duplicate widget instances and appended a helper to dedupe the DOM.
- Added a helper to append messages to the conversation log and maintained a `messages` array for conversation state.
- Set `MODEL = 'gpt-3.5-turbo'` and defined `proxyUrl` as `'https://tonyabdelmalak-github-' + 'io.vercel.app/api/chat-proxy'` to avoid line breaks.
- Added event listeners for DOMContentLoaded, toggle click, form submit, send button click, and keydown events to send messages.

Verification checklist:
- [ ] Widget opens/closes without console errors and only one instance exists.
- [ ] POST requests to https://tonyabdelmalak-github-io.vercel.app/api/chat-proxy return 200 OK and include a non-empty assistant reply.
- [ ] No duplicate DOM nodes (#hf-chat-wrapper, #hf-chat-toggle, #hf-chat-container).
- [ ] Vercel production deployment completes and chat works end-to-end.
